### PR TITLE
Added module "manualdock"

### DIFF
--- a/fpcup.ini
+++ b/fpcup.ini
@@ -1797,7 +1797,7 @@ UnInstall=rm -Rf $(Installdir)
 
 [FPCUPModule187]
 Name=manualdock
-Description="This IDE extension allows the Messages window to dock to the source editor."
+Description="This IDE extension allows the Messages window to dock to the source editor. Go to [View]->[Dock Messages window]."
 Enabled=0
 Installdir=$(basedir)/ccr/$(name)
 SVNURL=http://svn.code.sf.net/p/lazarus-ccr/svn/components/manualdock

--- a/fpcup.ini
+++ b/fpcup.ini
@@ -1795,3 +1795,12 @@ GITURL=https://github.com/novuslogic/DelphiAWSSDK
 ArchiveURL=https://github.com/novuslogic/DelphiAWSSDK/archive/master.zip
 UnInstall=rm -Rf $(Installdir)
 
+[FPCUPModule187]
+Name=manualdock
+Description="This IDE extension allows the Messages window to dock to the source editor."
+Enabled=0
+Installdir=$(basedir)/ccr/$(name)
+SVNURL=http://svn.code.sf.net/p/lazarus-ccr/svn/components/manualdock
+UnInstall=rm -Rf $(Installdir)
+AddPackage=$(installdir)/manualdock.lpk
+


### PR DESCRIPTION
It allows docking the message window to the bottom of the source editor. Quite handy. Tested this on windows and it worked.