### PR TITLE
Add ability to use parameters with lazarus home startlink.

### DIFF
--- a/fpcuputil.pas
+++ b/fpcuputil.pas
@@ -1218,7 +1218,7 @@ begin
     SysUtils.DeleteFile(ScriptFile); //Get rid of any existing remnants
     ScriptText.Add('#!/bin/sh');
     ScriptText.Add('# '+BeginSnippet+' home startlink script');
-    ScriptText.Add(Target+' '+TargetArguments);
+    ScriptText.Add(Target+' '+TargetArguments+' "$@"');
     try
       ScriptText.SaveToFile(ScriptFile);
       FpChmod(ScriptFile, &755); //rwxr-xr-x


### PR DESCRIPTION
Hello, 
This little patch allows parameters to be passed to lazarus executable.

So you can do something like:
`/home/user/Lazarus_fpcupdeluxe --version` And it will work.

You can also open lazarus with some file like:

`/home/user/Lazarus_fpcupdeluxe pascal_file.pas`

