### PR TITLE
simplify TGitClient.GetLocalRevision(), git describe is really the only thing we need

### DIFF
--- a/gitclient.pas
+++ b/gitclient.pas
@@ -640,51 +640,21 @@ begin
   if NOT ValidClient then exit;
   if NOT DirectoryExists(LocalRepository) then exit;
 
-  // Only update if we have invalid revision info, in order to minimize git info calls
+  // Only update if we have invalid revision info, in order to minimize git describe calls
   if (FLocalRevision = FRET_UNKNOWN_REVISION) then
   begin
     try
-
-      if (FLocalRevision = FRET_UNKNOWN_REVISION) then
-      begin
-        FReturnCode := TInstaller(Parent).ExecuteCommandInDir(FRepoExecutable,['log','-g','-1','--pretty=oneline'],LocalRepository, Output, '', Verbose);
-        if (FReturnCode = 0) then
-        begin
-          i:=RPos(' to ',Output);
-          if (i>0) then
-          begin
-            Delete(Output,1,(i+3));
-            // Do we have this format : branchname-xxxx-gxxxx
-            if (OccurrencesOfChar(Output,'-')=2) then
-              FLocalRevision := trim(Output);
-          end;
-        end
-      end;
-
-      if (FLocalRevision = FRET_UNKNOWN_REVISION) then
-      begin
-        FReturnCode := TInstaller(Parent).ExecuteCommandInDir(FRepoExecutable,['describe','--tags','--all','--long','--always'],LocalRepository, Output, '', Verbose);
-        if (FReturnCode = 0) then
-        begin
-          if (NOT AnsiStartsText('remotes/',Output)) then
-          begin
-            i:=RPos('/',Output);
-            if (i>0) then Delete(Output,1,i);
-            // Do we have this format : branchname-xxxx-gxxxx
-            if (OccurrencesOfChar(Output,'-')=2) then
-              FLocalRevision := trim(Output);
-          end;
-        end;
-      end;
-
       if (FLocalRevision = FRET_UNKNOWN_REVISION) then
       begin
         FReturnCode := TInstaller(Parent).ExecuteCommandInDir(FRepoExecutable,['describe','--tags','--long','--always'],LocalRepository, Output, '', Verbose);
         if (FReturnCode = 0) then
         begin
-          // Do we have this format : branchname-xxxx-gxxxx
-          if (OccurrencesOfChar(Output,'-')=2) then
-            FLocalRevision := trim(Output);
+          // git describe will *always* output the most reasonable revision info,
+          // if it outputs anything at all we can just use it as it is.
+          // if there are any tags in this branch it will output "<tag>-<ahead>-g<hash>"
+          // and if there are no tags then it will just output "<hash>",
+          // both of these are guaranteed to be commit-ish names, usable in other git commands.
+          FLocalRevision := trim(Output);
         end
       end;
 


### PR DESCRIPTION
`git describe --tags --long --always` will always output a valid commit-ish name.

If there were no tags in the entire branch it would output a commit hash
If it finds a tag in the current branch (using the most recent tag) it will output `<tag>-<ahead>-g<hash>`

Both of these two possible outputs are commit-ish names, that is they can be used anywhere in git where you want to refer to a specific commit, you can directly checkout using one of these names, use them for rebase or merge or anything. You can even use them if someone were to delete the tags they refer to because it still contains the abbreviated git hash after the "g" and git is smart enough to use that to find the commit.

So I have removed the other two attempts to get information from git and use only this one call to fit all needs: git describe. Also there is no need to inspect this string and count the minus signs (it has more than 2 anyways because in the Lazarus repo the branch start tags have names like `t-<branchname>`), whatever it outputs it will always be valid and usable because the `--always` option makes it fall back to hash whenever it fails to find a tag.

fixes #413
