### PR TITLE
desktop shortcut: Exec MUST be absolute path as per specification, fixes #419

### DIFF
--- a/fpcuputil.pas
+++ b/fpcuputil.pas
@@ -1056,12 +1056,8 @@ begin
     XdgDesktopContent.Add('Encoding=UTF-8');
     XdgDesktopContent.Add('Type=Application');
     XdgDesktopContent.Add('Icon='+ExtractFilePath(Target)+'images/icons/lazarus.ico');
-    {$ifdef LCLQT5}
     XdgDesktopContent.Add('Path='+ExtractFilePath(Target));
-    XdgDesktopContent.Add('Exec=./'+ExtractFileName(Target)+' '+TargetArguments+' %f');
-    {$else}
     XdgDesktopContent.Add('Exec='+Target+' '+TargetArguments+' %f');
-    {$endif}
     XdgDesktopContent.Add('Name='+ShortcutName);
     XdgDesktopContent.Add('GenericName=Lazarus IDE with Free Pascal Compiler');
     XdgDesktopContent.Add('Category=Application;IDE;Development;GUIDesigner;Programming;');


### PR DESCRIPTION
as per the freedesktop specification `Exec=` must either be an absolute path or it must be a file that is in `$PATH`. A relative path will not work anymore in recent version of KDE (has worked before but stopped working)

I removed the $ifdef and it will now always create an absolute path.

Fixes #419 
