### PR TITLE
remove changing main window position for Qt5

### DIFF
--- a/installerlazarus.pas
+++ b/installerlazarus.pas
@@ -1141,15 +1141,6 @@ begin
       LazarusConfig:=TUpdateLazConfig.Create(FPrimaryConfigPath);
       try
 
-        {$ifdef LCLQT5}
-        //Set default sizes and position
-        LazarusConfig.SetVariable(EnvironmentConfig, 'Desktops/Desktop1/MainIDE/CustomPosition/Left', '10');
-        LazarusConfig.SetVariable(EnvironmentConfig, 'Desktops/Desktop1/MainIDE/CustomPosition/Top', '30');
-        LazarusConfig.SetVariable(EnvironmentConfig, 'Desktops/Desktop1/MainIDE/CustomPosition/Width', '900');
-        LazarusConfig.SetVariable(EnvironmentConfig, 'Desktops/Desktop1/MainIDE/CustomPosition/Height', '60');
-        LazarusConfig.SetVariable(EnvironmentConfig, 'Desktops/Desktop1/MainIDE/Visible/Value', 'True');
-        {$endif}
-
         {$ifdef Haiku}
         //Set default font
         LazarusConfig.SetVariable(EditorConfig, 'EditorOptions/Display/DoNotWarnForFont', 'Noto Mono');


### PR DESCRIPTION
This PR removes the spacial handling of Qt5 settings for main window entirely. 

Merge this only if you are sure there is really no need for it anymore.

Fixes #423

