### PR TITLE
Option to disable confirmation dialog

### DIFF
--- a/extrasettings.pas
+++ b/extrasettings.pas
@@ -166,6 +166,9 @@ type
     function GetAddContext:boolean;
     procedure SetAddContext(value:boolean);
 
+    function GetAskConfirmation:boolean;
+    procedure SetAskConfirmation(value:boolean);
+
     function GetHTTPProxyHost:string;
     function GetHTTPProxyPort:integer;
     function GetHTTPProxyUser:string;
@@ -243,6 +246,7 @@ type
     property UseSoftFloat:boolean read GetUseSoftFloat write SetUseSoftFloat;
     property OnlinePatching:boolean read GetAllowOnlinePatching write SetAllowOnlinePatching;
     property AddContext:boolean read GetAddContext write SetAddContext;
+    property AskConfirmation:boolean read GetAskConfirmation write SetAskConfirmation;
 
     property HTTPProxyHost:string read GetHTTPProxyHost;
     property HTTPProxyPort:integer read GetHTTPProxyPort;
@@ -326,6 +330,9 @@ resourcestring
 
   HintCheckAddContext = 'Double clicking on FPC and Lazarus files will open Lazarus.';
   CaptionCheckAddContext = 'Add context for FPC and Lazarus files.';
+
+  HintCheckAskConfirmation = 'Show a confirmation dialog with yes/no before every build.';
+  CaptionCheckAskConfirmation = 'Always ask for confirmation (default=yes).';
 
 var
   Form2: TForm2;
@@ -438,6 +445,7 @@ begin
     Append(CaptionUseSoftFloat80bit);
     Append(CaptionCheckEnableOnlinePatching);
     Append(CaptionCheckAddContext);
+    Append(CaptionCheckAskConfirmation);
   end;
 
   with TIniFile.Create(SafeGetApplicationPath+installerUniversal.DELUXEFILENAME) do
@@ -487,6 +495,7 @@ begin
 
   SplitFPC:=true;
   MakeJobs:=true;
+  AskConfirmation := true;
 
   Self.LazarusDebug:=true;
 
@@ -1335,6 +1344,14 @@ begin
   SetCheckState(CaptionCheckAddContext,value);
 end;
 
+function TForm2.GetAskConfirmation: boolean;
+begin
+  result := GetCheckState(CaptionCheckAskConfirmation);
+end;
+procedure TForm2.SetAskConfirmation(value: boolean);
+begin
+  SetCheckState(CaptionCheckAskConfirmation, value);
+end;
 
 function TForm2.GetFPCOptions:string;
 begin

--- a/fpcupdeluxemainform.pas
+++ b/fpcupdeluxemainform.pas
@@ -1078,10 +1078,9 @@ begin
   begin
     s:='Going to update all crosscompilers !' + sLineBreak +
        'Do you want to continue ?';
-    if (MessageDlg(s,mtConfirmation,[mbYes, mbNo],0)<>mrYes) then
-    begin
-      exit;
-    end;
+    if Form2.AskConfirmation then
+      if (MessageDlg(s,mtConfirmation,[mbYes, mbNo],0)<>mrYes) then
+        exit;
   end;
 
   if (Sender<>nil) then
@@ -2053,7 +2052,9 @@ begin
 
   s:=s+sLineBreak;
   s:=s+'Install directory: '+Self.sInstallDir;
-  if (MessageDlg(s+sLineBreak+'Do you want to continue ?',mtConfirmation,[mbYes, mbNo],0)<>mrYes) then exit;
+  if Form2.AskConfirmation then
+    if (MessageDlg(s+sLineBreak+'Do you want to continue ?',mtConfirmation,[mbYes, mbNo],0)<>mrYes) then
+      exit;
 
   if ( AnsiEndsText(GITLABEXTENSION,aFPCTarget) AND AnsiEndsText(GITLABEXTENSION,aLazarusTarget) AND (NOT chkGitlab.Checked) ) then
     chkGitlab.Checked:=true;
@@ -2262,7 +2263,9 @@ begin
     s:=s+'Install directory: '+Self.sInstallDir;
     s:=s+sLineBreak;
     s:=s+'Do you want to continue ?';
-    if (MessageDlg(s,mtConfirmation,[mbYes, mbNo],0)<>mrYes) then exit;
+    if Form2.AskConfirmation then
+      if (MessageDlg(s,mtConfirmation,[mbYes, mbNo],0)<>mrYes) then
+        exit;
 
     if Sender=btnInstallModule then
     begin
@@ -2803,10 +2806,9 @@ begin
       if (length(s)=0) then
         s:='Do you want to continue ?';
       s:='Going to install the cross-compiler for' + sLineBreak + '['+FPCupManager.CrossCombo_Target+']' + sLineBreak + s;
-      if (MessageDlg(s,mtConfirmation,[mbYes, mbNo],0)<>mrYes) then
-      begin
-        exit;
-      end;
+      if Form2.AskConfirmation then
+        if (MessageDlg(s,mtConfirmation,[mbYes, mbNo],0)<>mrYes) then
+          exit;
     end;
 
     DisEnable(Sender,False);

--- a/fpcupdeluxemainform.pas
+++ b/fpcupdeluxemainform.pas
@@ -3708,15 +3708,17 @@ begin
     exit;
   end;
 
-  s:='';
-  if Sender=BitBtnFPCOnly then s:='Going to install/update FPC.';
-  if Sender=BitBtnLazarusOnly then s:='Going to install/update Lazarus.';
-  if Sender=BitBtnFPCandLazarus then s:='Going to install/update FPC and Lazarus.';
-  s:=s+sLineBreak;
-  s:=s+'Install directory: '+Self.sInstallDir;
-  s:=s+sLineBreak;
-  s:=s+'Do you want to continue ?';
-  if (MessageDlg(s,mtConfirmation,[mbYes, mbNo],0)<>mrYes) then exit;
+  if Form2.AskConfirmation then begin
+    s:='';
+    if Sender=BitBtnFPCOnly then s:='Going to install/update FPC.';
+    if Sender=BitBtnLazarusOnly then s:='Going to install/update Lazarus.';
+    if Sender=BitBtnFPCandLazarus then s:='Going to install/update FPC and Lazarus.';
+    s:=s+sLineBreak;
+    s:=s+'Install directory: '+Self.sInstallDir;
+    s:=s+sLineBreak;
+    s:=s+'Do you want to continue ?';
+    if (MessageDlg(s,mtConfirmation,[mbYes, mbNo],0)<>mrYes) then exit;
+  end;
 
   DisEnable(Sender,False);
   try
@@ -4516,6 +4518,8 @@ begin
 
       Form2.ForceLocalRepoClient:=ReadBool('General','ForceLocalRepoClient',Form2.ForceLocalRepoClient);
 
+      Form2.AskConfirmation:=ReadBool('General','AskConfirmation',Form2.AskConfirmation);
+
     finally
       Free;
     end;
@@ -4613,6 +4617,8 @@ begin
       WriteBool('General','FpcupBootstrappersOnly',Form2.FpcupBootstrappersOnly);
 
       WriteBool('General','ForceLocalRepoClient',Form2.ForceLocalRepoClient);
+
+      WriteBool('General','AskConfirmation',Form2.AskConfirmation);
 
       UpdateFile;
     finally


### PR DESCRIPTION
For impatient users it would be an advantage to have the ablity to turn off the annoying confirmation dialog that pops up every time one clicks on any of the install buttons. I introduced a new setting (ini file and settings dialog) to do just that. The default remains enabled so nothing changes for existing users.