### PR TITLE
Update Zeos stable reference to Zeos 7.2.14

### DIFF
--- a/fpcup.ini
+++ b/fpcup.ini
@@ -1054,7 +1054,7 @@ Enabled=0
 Installdir=$(basedir)/ccr/$(name)
 ; Page with list of svn repos:
 ; http://zeoslib.sourceforge.net/viewtopic.php?f=1&t=3654&sid=9c21e65a2eda5eb9ad17d4be3ce55932
-SVNURL=svn://svn.code.sf.net/p/zeoslib/code-0//tags/7.2.6-stable/
+SVNURL=svn://svn.code.sf.net/p/zeoslib/code-0/tags/7.2.14-stable/
 ; GITURL=https://github.com/marsupilami79/zeoslib
 ; Branch=7.2.6-stable
 AddPackage=$(Installdir)/packages/lazarus/zcomponent.lpk


### PR DESCRIPTION
Zeos users reported that fpcupdeluxe installs Zeos 7.2.6 ([https://sourceforge.net/p/zeoslib/tickets/516/#2ac9/cb40](https://sourceforge.net/p/zeoslib/tickets/516/#2ac9/cb40)).
Zeos 7.2.6 is quite old now. This patch changes the reference in fpcup.ini file to Zeos 7.2.14, which is the current stable release.