### PR TITLE
Fix go32v2 cross

### DIFF
--- a/crossinstallers/m_any_to_go32v2i386.pas
+++ b/crossinstallers/m_any_to_go32v2i386.pas
@@ -122,7 +122,7 @@ begin
 
 
   {$ifndef WIN32}
-  AsFile:=FBinUtilsPrefix+'as.exe';
+  AsFile:=FBinUtilsPrefix+'as'+GetExeExt;
 
   result:=SearchBinUtil(BasePath,AsFile);
   if not result then
@@ -131,7 +131,7 @@ begin
   if not result then
   begin
     FBinUtilsPrefix:=GetCPU(TargetCPU)+'-go32-';
-    AsFile:=FBinUtilsPrefix+'as.exe';
+    AsFile:=FBinUtilsPrefix+'as'+GetExeExt;
     result:=SearchBinUtil(BasePath,AsFile);
     if not result then
       result:=SimpleSearchBinUtil(BasePath,DirName,AsFile);

--- a/fpcupdeluxemainform.lfm
+++ b/fpcupdeluxemainform.lfm
@@ -4160,6 +4160,7 @@ object Form1: TForm1
           'morphos'
           'aros'
           'amiga'
+          'go32v2'
           'ios'
           'freertos'
           'ultibo'


### PR DESCRIPTION
go32v2 was not in the OS list on the Cross tab, so I added it.

I also replaced the hardcoded .exe extension with GetExeExt to allow installing on Linux.