### PR TITLE
Fix installation of pas2js_rtl

### DIFF
--- a/sources/installeruniversal.pas
+++ b/sources/installeruniversal.pas
@@ -2538,7 +2538,7 @@ end;
 
 function TPas2jsInstaller.BuildModule(ModuleName: string): boolean;
 var
-  Workingdir,FilePath:string;
+  Workingdir,FilePath,OldPathFPCD:string;
   idx:integer;
   sl:TStringList;
   {$ifndef FPCONLY}
@@ -2578,11 +2578,16 @@ begin
   Processor.Process.Parameters.Clear;
   Processor.Executable:=Make;
   Processor.Process.CurrentDirectory := ExcludeTrailingPathDelimiter(Workingdir);
+    
+  //Store the FPCDIR environment variable
+  OldPathFPCD:=Processor.Environment.GetVar('FPCDIR');
+
   //Processor.SetParamNamePathData('FPC',FCompiler);
   Processor.SetParamNamePathData('PP',FCompiler);
   //Processor.SetParamNamePathData('PP',ExtractFilePath(FCompiler)+GetCompilerName(GetSourceCPU));
   //Processor.SetParamNamePathData('FPCDIR',IncludeTrailingPathDelimiter(Workingdir)+'compiler');
-
+  Processor.Environment.SetVar('FPCDIR',FFPCSourceDir);
+  
   Processor.SetParamData('clean');
   Processor.SetParamData('all');
 
@@ -2591,6 +2596,9 @@ begin
   try
     ProcessorResult:=Processor.ExecuteAndWait;
     result := (ProcessorResult=0);
+    
+    //Restore FPCDIR environment variable
+    Processor.Environment.SetVar('FPCDIR',OldPathFPCD);	
 
     if (NOT result) then
     begin


### PR DESCRIPTION
We currently have the following errors:
Windows: 
`Warning: Source file "pas2js.pp" from package pas2js not found for x86_64-win64`

Linux:
`Warning: Source file "pas2js.pp" from package pas2js not found for x86_64-linux`

In the pas2js source code, in fpmake.pp:
``` pascal 
FPCSrcDir:=GetEnvironmentVariable('FPCDIR');
  if FPCSrcDir<>'' then
    FPCSrcDir:=IncludeTrailingPathDelimiter(ExpandFileName(FPCSrcDir));
  if FPCSrcDir='' then
    FPCSrcDir:=IncludeTrailingPathDelimiter(GetCurrentDir)+'compiler'+PathDelim;
``` 

Inside function TPas2jsInstaller.BuildModule
Set FPCDIR environment variable
``` pascal 
Processor.Environment.SetVar('FPCDIR',FFPCSourceDir);
``` 

And finally I restore it
``` pascal 
Processor.Environment.SetVar('FPCDIR',OldPathFPCD);
``` 